### PR TITLE
NixOS development shell, VI-style focus switching support.

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -9,6 +9,9 @@
 #define REVERSE_ITALICS
  */
 
+/* To aid debugging of wget_wch key codes, define DEBUG_WCH, which will print them out.  */
+//#define DEBUG_WCH
+
 /* mtm by default will advertise itself as a "screen-bce" terminal.
  * This is the terminal type advertised by such programs as
  * screen(1) and tmux(1) and is a widely-supported terminal type.
@@ -30,7 +33,7 @@
  * to follow after the escape key is pressed before sending it on to
  * the focused virtual terminal.
  */
-#define ESCAPE_TIME 500
+#define ESCAPE_TIME 50
 
 /* mtm supports a scrollback buffer, allowing users to scroll back
  * through the output history of a virtual terminal. The SCROLLBACK
@@ -55,6 +58,17 @@
 #define MOVE_RIGHT      CODE(KEY_RIGHT)
 #define MOVE_LEFT       CODE(KEY_LEFT)
 #define MOVE_OTHER      KEY(L'o')
+
+/* VI-style movement, for use with ALT-<KEY>.
+   ALT+<KEY> must be HELD DOWN while pressing the movement key.
+   This is how we can identify it from an ESCAPE press.
+ */
+#define ALT_COMMAND_KEY     27
+#define ALT_MOVE_UP         KEY(L'k')
+#define ALT_MOVE_DOWN       KEY(L'j')
+#define ALT_MOVE_RIGHT      KEY(L'l')
+#define ALT_MOVE_LEFT       KEY(L'h')
+#define ALT_MOVE_OTHER      KEY(L'o')
 
 /* The split terminal keys. */
 #define HSPLIT KEY(L'h')

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchFromGitHub, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "mtm";
+  version = "1.2.1";
+
+  outputs = [ "out" "terminfo" ];
+
+  src = lib.cleanSource ./.;
+
+  #src = fetchFromGitHub {
+  #  owner = "deadpixi";
+  #  repo = pname;
+  #  rev = version;
+  #  sha256 = "0gibrvah059z37jvn1qs4b6kvd4ivk2mfihmcpgx1vz6yg70zghv";
+  #};
+
+  buildInputs = [ ncurses ];
+
+  makeFlags = [ "DESTDIR=${placeholder "out"}" "MANDIR=${placeholder "out"}/share/man/man1" ];
+
+  preInstall = ''
+    mkdir -p $out/bin/ $out/share/man/man1
+  '';
+
+  postInstall = ''
+    mkdir -p $terminfo/share/terminfo $out/nix-support
+    tic -x -o $terminfo/share/terminfo mtm.ti
+    echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
+  '';
+
+  meta = with lib; {
+    description = "Perhaps the smallest useful terminal multiplexer in the world";
+    homepage = "https://github.com/deadpixi/mtm";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.marsam ];
+    mainProgram = "mtm";
+  };
+}

--- a/mtm.c
+++ b/mtm.c
@@ -1146,6 +1146,11 @@ handlechar(int r, int k) /* Handle a single input character. */
     cmd = false;
 
     if (cancel) {
+        // send the escape char!
+        if (wctomb(c, ALT_COMMAND_KEY) > 0) {
+          SEND(n, c);
+        }
+
 #ifdef DEBUG_WCH
         fprintf(stderr, "\nCancel: %d\n", cancel);
 #endif

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  mtm = pkgs.callPackage ./default.nix { };
+in
+pkgs.mkShell rec {
+  buildInputs = [ mtm ];
+
+  LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
+
+  shellHook = ''
+    export PS1="''${debian_chroot:+($debian_chroot)}\[\033[01;39m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\W\[\033[00m\]\$ "
+    export PS1="(mtm)$PS1"
+  '';
+}
+

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@ let
   mtm = pkgs.callPackage ./default.nix { };
 in
 pkgs.mkShell rec {
-  buildInputs = [ mtm ];
+  buildInputs = [ mtm pkgs.ncurses ];
 
   LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
 


### PR DESCRIPTION
Personal tweaks for my own usage. 
This adds `ALT` commands, which are an alternative to the default `CTRL-G` command-mode shortcut,
which is faster to activate (and more ergonomic, imo).

So far I've added the following alternate commands:
 - `ALT-<K/J/H/L>`, change focus UP/DOWN/LEFT/RIGHT between windows
 - `ALT-O`, move focus to the previously active window